### PR TITLE
#11 installed terraform provider, created s3 bucket skeleton

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.16.2"
+  constraints = "5.16.2"
+  hashes = [
+    "h1:bsPS1G10A6F2zOVh3lCuzF+vvxOzq8Ffm/uJvGB4C60=",
+    "zh:00697204583b32e880abe73eb37814f34c07c9b3294f5c85755ee02cbdfcaa92",
+    "zh:1345d8b2ab9ddcf25d313152f17fd139a1d570229542949dc819184bf851305e",
+    "zh:14a0d2de839d26b8607078de059be328a47d60cee95756fb1c1500b3c6b552a2",
+    "zh:15f7c1f561df4e596f69d983014850c6e29c7025921a1d45150e23162e9bbfa7",
+    "zh:3587de4370db87b0955e08bb521cc8b15ba3c616a4a22238b2934bc7d7e3dc3e",
+    "zh:4e98960e8e1ad18a079e83e7a86806a2dd7a28ac67a100471776e424f5d02140",
+    "zh:674eaa30c90410a0d0c2ef52f5ad47c74f186fe2e7e03475bfeca5bcda67a490",
+    "zh:683eb032f5dce2673d25c48c50e1fe88cbb0d255640babad496767f3db5993fd",
+    "zh:6f157679a955ff43c468169bcb412b555bbd6b9664a61a4e71019df307e80f1c",
+    "zh:720c6c3873b36e361477f0ed2920803e35773cb652d51c757b3581d0db08e6e5",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e86cc849446901c77c05d6735271befb443b18fd84890b00aaef6a11ab54212",
+    "zh:a02ecab0f8d68a7f7ed6b2e37a53999d234606e5b8f65f2c3bcfb82826131f00",
+    "zh:a9d545217cd339ddfb0b9061a89e82022d727d654bddac294eb0d544a3367fbc",
+    "zh:b5a495582adb2c92cff67013c9083f7a08b9295e29af816c541177eb989a20ee",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = "3.5.1"

--- a/README.md
+++ b/README.md
@@ -232,3 +232,8 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 - Mercifully, we have `terraform.tfstate.backup` which is the previous state of the backup, as per the `serial`
 
 
+#### Terraform **Destroy**
+
+- It's a command to nuke the infrastructure resources `terraform destroy`
+It will display a list of resources that it plans to destroy, to which we can `-- auto-approve` to expedite. 
+- Terraform will initiate the process to destroy those resources,

--- a/bin/install_terraform_cli
+++ b/bin/install_terraform_cli
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 PROJECT_ROOT='/workspace/terraform-beginner-bootcamp-2023'
-cd /workspace 
 sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl
 
 wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg

--- a/main.tf
+++ b/main.tf
@@ -4,17 +4,30 @@ terraform {
       source = "hashicorp/random"
       version = "3.5.1"
     }
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.16.2"
+    }
   }
 }
 
 provider "random" {
   # Configuration options
 }
+provider "aws" {
+  # Configuration options
+}
 
 resource "random_string" "bucket_name" {
-  length           = 16
+  length           = 27
   special          = false
+  upper = false
 }
+#[S3 Resource Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket)
+resource "aws_s3_bucket" "example" {
+bucket = random_string.bucket_name.result
+  }
+#[S3 Naming Conventions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
 
 output "random_bucket_name" {
     value = random_string.bucket_name.result


### PR DESCRIPTION
Adjusted the random string generation to ensure the generated string only contains lowercase alphanumeric characters and hyphens
- Used the lower function to convert the bucket name to lowercase when defining the bucket resource
- - Ensure that the generated string's length complies with AWS naming rules (between 3 and 63 characters).
- Spun up Bucket, verified within AWS
- Terraform Destroyed to tear down resources